### PR TITLE
feat: scaffold cooldown manager web app

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>UOO Cooldown Manager</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "uoo-cooldown-manager",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "echo \"No tests\""
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "zod": "^3.23.8",
+    "fast-xml-parser": "^4.3.2",
+    "@reduxjs/toolkit": "^1.9.7",
+    "react-redux": "^8.1.3",
+    "@mantine/core": "^7.0.0",
+    "@mantine/hooks": "^7.0.0",
+    "@emotion/react": "^11.11.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5",
+    "@types/react": "^18.2.14",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,190 @@
+import React, { useEffect } from 'react';
+import { CooldownEntry, Trigger } from './types';
+import { parseCooldowns, buildCooldowns } from './xmlUtils';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  RootState,
+  AppDispatch,
+  setData,
+  setError,
+  addEntry,
+  updateEntry,
+  deleteEntry,
+} from './store';
+import {
+  Button,
+  Container,
+  Title,
+  FileInput,
+  Alert,
+  Paper,
+  TextInput,
+  NumberInput,
+  Checkbox,
+  Group,
+  Stack,
+  Text,
+} from '@mantine/core';
+
+export default function App() {
+  const dispatch = useDispatch<AppDispatch>();
+  const data = useSelector((state: RootState) => state.cooldowns.data);
+  const error = useSelector((state: RootState) => state.cooldowns.error);
+
+  useEffect(() => {
+    fetch('/cooldowns.xml')
+      .then((res) => (res.ok ? res.text() : null))
+      .then((xml) => {
+        if (!xml) return;
+        try {
+          const parsed = parseCooldowns(xml);
+          dispatch(setData(parsed));
+        } catch {
+          /* ignore */
+        }
+      })
+      .catch(() => {});
+  }, []);
+
+  const handleFile = (file: File) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        const parsed = parseCooldowns(reader.result as string);
+        dispatch(setData(parsed));
+        dispatch(setError(null));
+      } catch (e) {
+        dispatch(setError('Failed to parse XML'));
+      }
+    };
+    reader.readAsText(file);
+  };
+
+  const onAddEntry = () => dispatch(addEntry());
+
+  const onUpdateEntry = (index: number, entry: CooldownEntry) =>
+    dispatch(updateEntry({ index, entry }));
+
+  const onDeleteEntry = (index: number) => dispatch(deleteEntry(index));
+
+  const download = () => {
+    if (!data) return;
+    const xml = buildCooldowns(data);
+    const blob = new Blob([xml], { type: 'application/xml' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'cooldowns.xml';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <Container p="md">
+      <Stack>
+        <Title order={1}>UOO Cooldown Manager</Title>
+        <FileInput
+          accept=".xml"
+          placeholder="Upload cooldowns.xml"
+          onChange={(file) => file && handleFile(file)}
+        />
+        {error && (
+          <Alert color="red" variant="light">
+            {error}
+          </Alert>
+        )}
+        {data && (
+          <Stack>
+            <Button onClick={onAddEntry}>Add Entry</Button>
+            {data.cooldowns.cooldownentry.map((entry, i) => (
+              <EntryEditor
+                key={i}
+                entry={entry}
+                onChange={(val) => onUpdateEntry(i, val)}
+                onDelete={() => onDeleteEntry(i)}
+              />
+            ))}
+            <Button onClick={download}>Download XML</Button>
+          </Stack>
+        )}
+      </Stack>
+    </Container>
+  );
+}
+
+function EntryEditor({
+  entry,
+  onChange,
+  onDelete,
+}: {
+  entry: CooldownEntry;
+  onChange: (e: CooldownEntry) => void;
+  onDelete: () => void;
+}) {
+  const update = (patch: Partial<CooldownEntry>) => onChange({ ...entry, ...patch });
+
+  const updateTrigger = (index: number, trigger: Trigger) => {
+    const triggers = [...entry.trigger];
+    triggers[index] = trigger;
+    update({ trigger: triggers });
+  };
+
+  const addTrigger = () => update({ trigger: [...entry.trigger, { triggertype: '', duration: 0, triggertext: '' }] });
+
+  const deleteTrigger = (index: number) => update({ trigger: entry.trigger.filter((_, i) => i !== index) });
+
+  return (
+    <Paper withBorder p="md" mt="md">
+      <Stack>
+        <TextInput label="Name" value={entry.name} onChange={(e) => update({ name: e.currentTarget.value })} />
+        <NumberInput
+          label="Default Cooldown"
+          value={entry.defaultcooldown}
+          onChange={(value) => update({ defaultcooldown: Number(value) })}
+        />
+        <TextInput
+          label="Cooldown Bar Type"
+          value={entry.cooldownbartype}
+          onChange={(e) => update({ cooldownbartype: e.currentTarget.value })}
+        />
+        <NumberInput label="Hue" value={entry.hue} onChange={(value) => update({ hue: Number(value) })} />
+        <Checkbox
+          label="Hide When Inactive"
+          checked={entry.hidewheninactive}
+          onChange={(e) => update({ hidewheninactive: e.currentTarget.checked })}
+        />
+        <Stack>
+          <Text fw={500}>Triggers</Text>
+          {entry.trigger.map((t, i) => (
+            <Group key={i} align="flex-end">
+              <TextInput
+                placeholder="Type"
+                value={t.triggertype}
+                onChange={(e) => updateTrigger(i, { ...t, triggertype: e.currentTarget.value })}
+              />
+              <NumberInput
+                placeholder="Duration"
+                value={t.duration}
+                onChange={(value) => updateTrigger(i, { ...t, duration: Number(value) })}
+              />
+              <TextInput
+                placeholder="Text"
+                value={t.triggertext}
+                onChange={(e) => updateTrigger(i, { ...t, triggertext: e.currentTarget.value })}
+              />
+              <Button color="red" variant="subtle" onClick={() => deleteTrigger(i)}>
+                Delete
+              </Button>
+            </Group>
+          ))}
+          <Button variant="light" onClick={addTrigger}>
+            Add Trigger
+          </Button>
+        </Stack>
+        <Button color="red" onClick={onDelete}>
+          Delete Entry
+        </Button>
+      </Stack>
+    </Paper>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import { Provider } from 'react-redux';
+import { store } from './store';
+import { MantineProvider } from '@mantine/core';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <Provider store={store}>
+      <MantineProvider>
+        <App />
+      </MantineProvider>
+    </Provider>
+  </React.StrictMode>
+);

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,0 +1,56 @@
+import { configureStore, createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { Cooldowns, CooldownEntry } from './types';
+
+interface CooldownState {
+  data: Cooldowns | null;
+  error: string | null;
+}
+
+const initialState: CooldownState = {
+  data: null,
+  error: null,
+};
+
+const cooldownSlice = createSlice({
+  name: 'cooldowns',
+  initialState,
+  reducers: {
+    setData(state, action: PayloadAction<Cooldowns>) {
+      state.data = action.payload;
+      state.error = null;
+    },
+    setError(state, action: PayloadAction<string | null>) {
+      state.error = action.payload;
+    },
+    addEntry(state) {
+      if (!state.data) return;
+      state.data.cooldowns.cooldownentry.push({
+        name: '',
+        defaultcooldown: 0,
+        cooldownbartype: 'Regular',
+        hue: 0,
+        hidewheninactive: true,
+        trigger: [],
+      });
+    },
+    updateEntry(state, action: PayloadAction<{ index: number; entry: CooldownEntry }>) {
+      if (!state.data) return;
+      state.data.cooldowns.cooldownentry[action.payload.index] = action.payload.entry;
+    },
+    deleteEntry(state, action: PayloadAction<number>) {
+      if (!state.data) return;
+      state.data.cooldowns.cooldownentry.splice(action.payload, 1);
+    },
+  },
+});
+
+export const { setData, setError, addEntry, updateEntry, deleteEntry } = cooldownSlice.actions;
+
+export const store = configureStore({
+  reducer: {
+    cooldowns: cooldownSlice.reducer,
+  },
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+
+export const TriggerSchema = z.object({
+  triggertype: z.string(),
+  duration: z.coerce.number().optional().default(0),
+  triggertext: z.string(),
+});
+export type Trigger = z.infer<typeof TriggerSchema>;
+
+export const CooldownEntrySchema = z.object({
+  name: z.string(),
+  defaultcooldown: z.coerce.number().optional().default(0),
+  cooldownbartype: z.string(),
+  hue: z.coerce.number().optional().default(0),
+  hidewheninactive: z.coerce.boolean().optional().default(false),
+  trigger: z
+    .union([TriggerSchema, z.array(TriggerSchema)])
+    .optional()
+    .transform((val) => (val ? (Array.isArray(val) ? val : [val]) : [])),
+});
+export type CooldownEntry = z.infer<typeof CooldownEntrySchema>;
+
+export const CooldownsSchema = z.object({
+  cooldowns: z.object({
+    cooldownentry: z
+      .union([CooldownEntrySchema, z.array(CooldownEntrySchema)])
+      .transform((val) => (Array.isArray(val) ? val : [val])),
+  }),
+});
+export type Cooldowns = z.infer<typeof CooldownsSchema>;

--- a/src/xmlUtils.ts
+++ b/src/xmlUtils.ts
@@ -1,0 +1,22 @@
+import { XMLParser, XMLBuilder } from 'fast-xml-parser';
+import { CooldownsSchema, Cooldowns } from './types';
+
+const parser = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: '',
+});
+
+const builder = new XMLBuilder({
+  ignoreAttributes: false,
+  attributeNamePrefix: '',
+  format: true,
+});
+
+export function parseCooldowns(xml: string): Cooldowns {
+  const parsed = parser.parse(xml);
+  return CooldownsSchema.parse(parsed);
+}
+
+export function buildCooldowns(data: Cooldowns): string {
+  return builder.build(data);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node"
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- set up React + TypeScript project with Vite and Zod
- add XML parsing utilities and schemas for cooldown entries
- implement basic UI to load, edit, add and download cooldowns
- manage cooldown state via Redux store
- integrate Mantine components for app and entry editor

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@emotion%2freact)*
- `npm test`
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aaeb5788b4832e826be86678011460